### PR TITLE
fix Handle http status header without message

### DIFF
--- a/Curl/CurlHeaderCollector.php
+++ b/Curl/CurlHeaderCollector.php
@@ -60,7 +60,7 @@ class CurlHeaderCollector extends HeaderCollector
      * @param string $header
      */
     private function parseHttp($header) {
-        list($version,$code,$message) = explode(" ", $header);
+        list($version,$code,$message) = array_pad(explode(" ", $header), 3, "");
 
         $this->transactionHeaders[] = $header;
         


### PR DESCRIPTION
Si le server envoie un header HTTP sans le message associé au CODE Http le client crash

	Remove one or more containers
	PHP Notice:  Undefined offset: 2 in /data/sites/vendor/evaisse/simple-http-bundle/Curl/CurlHeaderCollector.php on line 63

Les headers de retour dans mon cas :

	curl https://stash.XXXXXXX.com/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -H "Authorization: Bearer XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" -v

	< HTTP/1.1 200
	< Date: Mon, 25 Feb 2019 15:12:50 GMT
	< Server: Apache
	< Strict-Transport-Security: max-age=15552001; includeSubDomains; preload
	< X-AREQUESTID: @XINL9Vx972x266027x1
	< X-ASEN: SEN-2783127
	< X-AUSERID: 6767
	< X-AUSERNAME: web-pr-helper-01
	< X-ASESSIONID: 5lhf2y
	< Cache-Control: private, no-cache
	< Pragma: no-cache
	< Cache-Control: no-cache, no-transform
	< Vary: X-AUSERNAME,Accept-Encoding
	< Content-Type: application/json;charset=UTF-8
	< X-Content-Type-Options: nosniff
	< Via: 1.1 stash.XXXXXXX.com
	< Transfer-Encoding: chunked
