### PR TITLE
[issue-21] fix: read same header name 

### DIFF
--- a/Curl/CurlHeaderCollector.php
+++ b/Curl/CurlHeaderCollector.php
@@ -104,9 +104,19 @@ class CurlHeaderCollector extends HeaderCollector
                 );
 
             } else {
-
-                $this->headers[$name] = $value;
-
+                if (array_key_exists($name, $this->headers)) {
+                    // maybe we can have more than one header with same key (ex: set-cookie, xkey, ykey)
+                    if (is_array($this->headers[$name])) {
+                        $this->headers[$name] = array_merge($this->headers[$name], [$name]);
+                    } else {
+                        $this->headers[$name] = [
+                            $this->headers[$name],
+                            $name,
+                        ];
+                    }
+                } else {
+                    $this->headers[$name] = $value;
+                }
             }
         }
 


### PR DESCRIPTION
some http responses got more than one header with same name, in there case put all values in array