### PR TITLE
[WA-1435] Symfony 5 Request Serializer

### DIFF
--- a/DataCollector/ProfilerDataCollector.php
+++ b/DataCollector/ProfilerDataCollector.php
@@ -10,6 +10,7 @@ use evaisse\SimpleHttpBundle\Http\StatementEventMap;
 use evaisse\SimpleHttpBundle\Serializer\CustomGetSetNormalizer;
 use evaisse\SimpleHttpBundle\Http\Exception;
 
+use evaisse\SimpleHttpBundle\Serializer\RequestNormalizer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -285,7 +286,7 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
 
     public function fetchRequestInfos(Request $request)
     {
-        $normalizers = array(new CustomGetSetNormalizer());
+        $normalizers = array(new RequestNormalizer());
         $encoders = array(new JsonEncoder());
         $serializer = new Serializer($normalizers, $encoders);
 
@@ -310,18 +311,6 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
      */
     public function fetchResponseInfos(Response $response)
     {
-        if ($response->headers->get('charset', '') == "utf-8"
-            || stripos($response->headers->get('content-type', ''), 'utf-8') !== 0
-        ) {
-            $encoders = array(new LazyJsonEncoder());
-        } else {
-            $encoders = array(new LazyJsonEncoder());
-        }
-
-        $normalizers = array(new CustomGetSetNormalizer());
-        $encoders = array(new LazyJsonEncoder());
-        $serializer = new Serializer($normalizers, $encoders);
-
         $data = [
             'statusCode' => $response->getStatusCode(),
         ];
@@ -353,7 +342,7 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
         return $data;
     }
 
-    public function fetchErrorInfos(\Exception $error)
+    public function fetchErrorInfos(\Throwable $error)
     {
         return array(
             'class'         => get_class($error),

--- a/Serializer/RequestNormalizer.php
+++ b/Serializer/RequestNormalizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace evaisse\SimpleHttpBundle\Serializer;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+
+class RequestNormalizer extends GetSetMethodNormalizer
+{
+    protected function getAttributeValue(object $object, string $attribute, string $format = null, array $context = [])
+    {
+        $ucfirsted = ucfirst($attribute);
+
+        $haser = 'has'.$ucfirsted;
+        if ($object instanceof Request && $attribute === 'session' && !$object->$haser()) {
+            return null;
+        }
+
+        return parent::getAttributeValue($object, $attribute, $format, $context);
+    }
+}


### PR DESCRIPTION
Create a new serializer to handle Request.
Since SF5, you can't call getSession from a request when session hasn't been set so the serializer need to check it before trying to fetch it