### PR TITLE
[fix-missing-props] fix potential missing key when call is interrupte…

### DIFF
--- a/DataCollector/ProfilerDataCollector.php
+++ b/DataCollector/ProfilerDataCollector.php
@@ -124,7 +124,7 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
                 'curlCommand'   => $this->buildCurlCommand($v['request']),
             );
 
-            if ($v['response']) {
+            if (isset($v['response'])) {
                 $calls[$k]['response']['fromHttpCache'] = false;
                 foreach ($calls[$k]['response']['headers'] as $h) {
                     foreach(['x-debug-uri:', 'x-debug-link:'] as $hk) {
@@ -259,6 +259,8 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
 
     public function fetchTransferInfos(array $call)
     {
+        $call['stop'] = isset($call['stop']) ? $call['stop'] : 0;
+
         $timing = array(
             'start'      => $call['start'],
             'stop'       => $call['stop'],


### PR DESCRIPTION
Fix potential missing props when profiler is interrupted inside a request/response processing