### PR TITLE
fix: Support missing responce status code in profiler twig function

### DIFF
--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -278,7 +278,7 @@ class Extension implements ExtensionInterface
             $level = 'default';
         }
 
-        $statusText = Response::$statusTexts[$code];
+        $statusText = Response::$statusTexts[$code] ?? null;
 
         return [
             'fromCache' => $fromCache,


### PR DESCRIPTION
When no response status available return null ass responses status text
For example because no response object as hostname could not be resovled at all
[support-no-response]