### PR TITLE
Change reset behavior in DataCollector/ProfilerDataCollector

### DIFF
--- a/DataCollector/ProfilerDataCollector.php
+++ b/DataCollector/ProfilerDataCollector.php
@@ -32,9 +32,8 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
 
     /**
      * list of potential errors indexed by requests
-     * @var array
      */
-    protected $errors = 0;
+    protected int $errors = 0;
 
 
     /**
@@ -656,7 +655,7 @@ class ProfilerDataCollector extends DataCollector implements EventSubscriberInte
     {
         $this->data = [];
         $this->calls = [];
-        $this->errors = [];
+        $this->errors = 0;
         $this->stopwatch->reset();
     }
 


### PR DESCRIPTION
fix: Fix an issue in profiler data collector where int $errors was reset to an array value