### PR TITLE
Invalid HTTP code in Profiler

### DIFF
--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -240,7 +240,7 @@ class Extension extends AbstractExtension
             $level = 'default';
         }
 
-        $statusText = $code === 'N/A' ? 'N/A' : Response::$statusTexts[$code];
+        $statusText = $code === 'N/A' ? 'N/A' : Response::$statusTexts[$code] ?? 'N/A';
 
         return [
             'fromCache' => $fromCache,


### PR DESCRIPTION
fix: Fix an issue when sending an HTTP code not defined in the RFC (like 420) is throwing an error